### PR TITLE
Add MessageData module to include `sparkpost_data` in Mail::Message

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sparkpost_rails (1.5.1)
+    sparkpost_rails (1.5.2)
       rails (>= 4.0, < 5.3)
 
 GEM

--- a/lib/sparkpost_rails.rb
+++ b/lib/sparkpost_rails.rb
@@ -1,6 +1,7 @@
 require "sparkpost_rails/data_options"
 require "sparkpost_rails/delivery_method"
 require "sparkpost_rails/exceptions"
+require "sparkpost_rails/message_data"
 require "sparkpost_rails/railtie"
 
 module SparkPostRails

--- a/lib/sparkpost_rails/data_options.rb
+++ b/lib/sparkpost_rails/data_options.rb
@@ -14,7 +14,9 @@ module SparkPostRails
           sparkpost_data = headers.delete(:sparkpost_data)
           sparkpost_data ||= {}
           super(headers, &block).tap do |message|
-            message.singleton_class.class_eval { attr_accessor "sparkpost_data" }
+            unless message.respond_to?(:sparkpost_data=)
+              message.singleton_class.class_eval { attr_accessor "sparkpost_data" }
+            end
             message.sparkpost_data = sparkpost_data
           end
         end

--- a/lib/sparkpost_rails/message_data.rb
+++ b/lib/sparkpost_rails/message_data.rb
@@ -1,0 +1,11 @@
+module SparkPostRails
+  module MessageData
+
+    def self.included(base)
+      base.class_eval do
+        attr_accessor :sparkpost_data
+      end
+    end
+
+  end
+end

--- a/lib/sparkpost_rails/railtie.rb
+++ b/lib/sparkpost_rails/railtie.rb
@@ -11,5 +11,11 @@ module SparkPostRails
         ActionMailer::Base.send :include, SparkPostRails::DataOptions
       end
     end
+
+    initializer 'sparkpost_rails.include_message_data' do
+      ActiveSupport.on_load :action_mailer do
+        Mail::Message.send :include, SparkPostRails::MessageData
+      end
+    end
   end
 end

--- a/lib/sparkpost_rails/version.rb
+++ b/lib/sparkpost_rails/version.rb
@@ -1,4 +1,4 @@
 module SparkPostRails
-  VERSION = "1.5.1"
+  VERSION = "1.5.2"
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ RSpec.configure do |config|
 
   config.before(:all) do
     ActionMailer::Base.send :include, SparkPostRails::DataOptions
+    Mail::Message.send :include, SparkPostRails::MessageData
   end
 
   config.before(:each) do |example|


### PR DESCRIPTION
`sparkpost_data` is addded to the message object through metaprogramming
in the `mail` method.  Instances of Mail::Message created outside of
this method (e.g. deserializing from a data store) will therefore not have
this attribute defined.  This change separates the attribute definition
to ensure it exists on the object's class and not just the instance's
singleton class.